### PR TITLE
Fix: follow 엔티티 매핑 오류 해결

### DIFF
--- a/src/main/java/F12/newsfeedproject/domain/follow/entity/Follow.java
+++ b/src/main/java/F12/newsfeedproject/domain/follow/entity/Follow.java
@@ -26,11 +26,11 @@ public class Follow {
     private Long followId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "fllower_id", nullable = false)
     private User follower;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "following_id", nullable = false)
     private User following;
 
 }


### PR DESCRIPTION
@JoinColumn의 매핑할 외래키 이름을 다르게해서 해결함

user_id -> follower_id
user_id -> following_id